### PR TITLE
Add affiliation input to CollaboratorManager and update related tests

### DIFF
--- a/__tests__/collaboratorManager.test.ts
+++ b/__tests__/collaboratorManager.test.ts
@@ -3,7 +3,6 @@
  */
 import { jest } from '@jest/globals'
 import * as core from '../__fixtures__/core.js'
-import { permission } from 'process'
 
 // Mocks should be declared before the module being tested is imported.
 jest.unstable_mockModule('@actions/core', () => core)

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: The path to the YAML file containing collaborator definitions
     required: false
     default: '.github/collaborators.yml'
+  affiliation:
+    description: The affiliation of the collaborators (e.g., direct, outside, all)
+    required: false
+    default: 'all'
   token:
     description: GitHub token with repo administration permissions
     required: true

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ inputs:
     required: false
     default: '.github/collaborators.yml'
   affiliation:
-    description: The affiliation of the collaborators (e.g., direct, outside, all)
+    description:
+      The affiliation of the collaborators (e.g., direct, outside, all)
     required: false
     default: 'all'
   token:


### PR DESCRIPTION
- Introduced 'affiliation' parameter in CollaboratorManager to manage collaborator types.
- Updated tests to reflect changes from 'role' to 'permission' for collaborator management.
- Modified action.yml to include 'affiliation' input with default value 'all'.